### PR TITLE
[TIM-485] Fixes displaynames for derived types

### DIFF
--- a/timbuctoo-core/src/main/java/nl/knaw/huygens/timbuctoo/graph/GraphBuilder.java
+++ b/timbuctoo-core/src/main/java/nl/knaw/huygens/timbuctoo/graph/GraphBuilder.java
@@ -108,7 +108,7 @@ public class GraphBuilder {
 
   private <T extends DomainEntity> D3Node createNode(T entity) {
     @SuppressWarnings("unchecked")
-    Class<T> type = (Class<T>) entity.getClass();
+    Class type = TypeRegistry.toBaseDomainEntity(entity.getClass());
     String key = TypeNames.getExternalName(type) + "/" + entity.getId();
     String iname = TypeNames.getInternalName(type);
     String label = entity.getIdentificationName();

--- a/timbuctoo-rest/src/main/java/nl/knaw/huygens/timbuctoo/rest/resources/GraphResource.java
+++ b/timbuctoo-rest/src/main/java/nl/knaw/huygens/timbuctoo/rest/resources/GraphResource.java
@@ -100,7 +100,6 @@ public class GraphResource extends ResourceBase {
   {
     Class<? extends DomainEntity> type = registry.getTypeForXName(entityName);
     checkNotNull(type, NOT_FOUND, "No domain entity collection %s", entityName);
-    type = TypeRegistry.toBaseDomainEntity(type);
 
     DomainEntity entity = repository.getEntityOrDefaultVariation(type, id);
     checkNotNull(entity, NOT_FOUND, "No %s with id %s", type.getSimpleName(), id);


### PR DESCRIPTION
The graph building code needs to know what kind of entity a node is. It's
logical to use the timbuctoo base types for this. However the retrieval of
the base type happened really early, having the side effect of using the
base type's view of the instance as well.