### PR TITLE
[TIM-647] Fixes bug that made it impossible to import relations

### DIFF
--- a/timbuctoo-core/src/main/java/nl/knaw/huygens/timbuctoo/storage/graph/tinkerpop/TinkerPopLowLevelAPI.java
+++ b/timbuctoo-core/src/main/java/nl/knaw/huygens/timbuctoo/storage/graph/tinkerpop/TinkerPopLowLevelAPI.java
@@ -221,7 +221,7 @@ class TinkerPopLowLevelAPI {
   }
 
   public Iterator<Edge> findEdgesWithoutProperty(Class<? extends Relation> relationType, String propertyName) {
-    Iterable<Edge> edges = db.query().hasNot(propertyName).edges();
+    Iterable<Edge> edges = queryByType(relationType).hasNot(propertyName).edges();
 
     return edges.iterator();
   }

--- a/timbuctoo-core/src/test/java/nl/knaw/huygens/timbuctoo/storage/graph/tinkerpop/TinkerPopLowLevelAPITest.java
+++ b/timbuctoo-core/src/test/java/nl/knaw/huygens/timbuctoo/storage/graph/tinkerpop/TinkerPopLowLevelAPITest.java
@@ -670,11 +670,12 @@ public class TinkerPopLowLevelAPITest {
   }
 
   @Test
-  public void findEdgesWithoutPropertyReturnsVerticesDoNotContainACertainProperty() {
+  public void findEdgesWithoutPropertyReturnsEdgesThatDoNotContainACertainProperty() {
     // setup
     Edge edge1 = anEdge().build();
     Edge edge2 = anEdge().build();
     EdgeSearchResultBuilder.QueryVerifier queryVerifier = anEdgeSearchResult()//
+      .forType(RELATION_TYPE) //
       .withoutProperty(PROPERTY_NAME)//
       .containsEdge(edge1) //
       .containsEdge(edge2) //
@@ -691,7 +692,7 @@ public class TinkerPopLowLevelAPITest {
   @Test
   public void findEdgesWithoutPropertyReturnsAnEmptyIteratorWhenNoneAreFound() {
     // setup
-    anEmptyEdgeSearchResult().withoutProperty(PROPERTY_NAME).foundInDatabase(dbMock);
+    anEmptyEdgeSearchResult().forType(RELATION_TYPE).withoutProperty(PROPERTY_NAME).foundInDatabase(dbMock);
 
     // action
     Iterator<Edge> vertices = instance.findEdgesWithoutProperty(RELATION_TYPE, PROPERTY_NAME);


### PR DESCRIPTION
The problem was that VERSION_OF edges were returned when searching for the non-persistent relations of the Charter VRE. Now the non-persistent relations will return only the relations that contain the type that is injected as the first parameter.