### PR TITLE
Fix bug in hiding duplicate symmetric relation

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/model/properties/JsonMetadata.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/model/properties/JsonMetadata.java
@@ -125,8 +125,16 @@ public class JsonMetadata {
         }
       });
     relations.stream()
-      .filter(v -> !getProp(v, "relationtype_sourceTypeName", String.class).orElse("").equals(abstractType))
-      .filter(v -> getProp(v, "relationtype_targetTypeName", String.class).orElse("").equals(abstractType))
+      .filter(v -> {
+        final String targetType = getProp(v, "relationtype_targetTypeName", String.class).orElse("");
+        final boolean isSymmetric = getProp(v, "relationtype_symmetric", Boolean.class).orElse(false);
+        if (isSymmetric) {
+          final String sourceType = getProp(v, "relationtype_sourceTypeName", String.class).orElse("");
+          return targetType.equals(abstractType) && !sourceType.equals(targetType);
+        } else {
+          return targetType.equals(abstractType);
+        }
+      })
       .forEach(v -> {
         String timId = getProp(v, "tim_id", String.class).orElse("<unknown>");
         Optional<String> regularName = getProp(v, "relationtype_regularName", String.class);


### PR DESCRIPTION
De code om een symmetrische relatie maar 1 keer te tonen is niet
helemaal correct. Dat zorgt ervoor dat voor een "niet symmetrische
relatie tussen twee objecten van hetzelfde type" (bijvoorbeeld
hasDocumentSource/isDocumentSourceOf) maar 1 van de twee relaties
getoond wordt (hasDocumentSource in dit geval)

TIM-1010