### PR TITLE
makes d3graph resource fetch only isLatest and accepted relations for…

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
@@ -20,27 +20,28 @@ public class D3Graph {
     links = Lists.newArrayList();
   }
 
-  public void addNode(Vertex vertex) {
+  public void addNode(Vertex vertex, String entityTypeName) {
     try {
-      Node node = new Node(vertex);
+      Node node = new Node(vertex, entityTypeName);
 
       if (!nodes.contains(node)) {
         nodes.add(node);
       }
 
     } catch (IOException e) {
-      LOG.warn("Node not added because " +  e.getMessage());
+      LOG.debug("Node not added because " +  e.getMessage());
     }
   }
 
-  public void addLink(Edge edge, Vertex source, Vertex target) {
+  public void addLink(Edge edge, Vertex source, Vertex target, String sourceTypeName, String targetTypeName) {
     try {
-      Link link = new Link(edge, nodes.indexOf(new Node(source)), nodes.indexOf(new Node(target)));
+      Link link = new Link(edge, nodes.indexOf(new Node(source, sourceTypeName)), nodes.indexOf(new Node(target,
+        targetTypeName)));
       if (!links.contains(link)) {
         links.add(link);
       }
     } catch (IOException e) {
-      LOG.warn("Link not added because " + e.getMessage());
+      LOG.debug("Link not added because " + e.getMessage());
     }
   }
 

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/GraphService.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/GraphService.java
@@ -1,6 +1,10 @@
 package nl.knaw.huygens.timbuctoo.graph;
 
 import nl.knaw.huygens.timbuctoo.crud.NotFoundException;
+import nl.knaw.huygens.timbuctoo.model.GraphReadUtils;
+import nl.knaw.huygens.timbuctoo.model.vre.Collection;
+import nl.knaw.huygens.timbuctoo.model.vre.Vre;
+import nl.knaw.huygens.timbuctoo.model.vre.Vres;
 import nl.knaw.huygens.timbuctoo.server.GraphWrapper;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
@@ -9,16 +13,34 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public class GraphService {
   private final GraphWrapper graphWrapper;
+  private Vres mappings;
 
-  public GraphService(GraphWrapper wrapper) {
+  public GraphService(GraphWrapper wrapper, Vres mappings) {
     this.graphWrapper = wrapper;
+    this.mappings = mappings;
   }
 
   public D3Graph get(String type, UUID uuid, List<String> relationNames, int depth) throws NotFoundException {
+
+    final String vreId = (String) graphWrapper.getGraph().traversal().V()
+                                              .hasLabel(Collection.DATABASE_LABEL)
+                                              .has(Collection.ENTITY_TYPE_NAME_PROPERTY_NAME, type)
+                                              .in(Vre.HAS_COLLECTION_RELATION_NAME).next()
+                                              .property(Vre.VRE_NAME_PROPERTY_NAME).value();
+
+    final String relationTypeName = (String) graphWrapper.getGraph().traversal().V()
+                                     .hasLabel(Collection.DATABASE_LABEL)
+                                     .has(Collection.ENTITY_TYPE_NAME_PROPERTY_NAME, type)
+                                     .in(Vre.HAS_COLLECTION_RELATION_NAME).out(Vre.HAS_COLLECTION_RELATION_NAME)
+                                     .where(__.has(Collection.IS_RELATION_COLLECTION_PROPERTY_NAME, true)).next()
+                                     .property(Collection.ENTITY_TYPE_NAME_PROPERTY_NAME).value();
+
+
     GraphTraversal<Vertex, Vertex> result = graphWrapper.getGraph().traversal().V()
             .has("tim_id", uuid.toString()).filter(
               x -> ((String) x.get().property("types").value()).contains("\"" + type + "\"")
@@ -33,33 +55,50 @@ public class GraphService {
     Vertex vertex = result.next();
     D3Graph d3Graph = new D3Graph();
 
-    generateD3Graph(d3Graph, vertex, relationNames, depth, 1);
+    generateD3Graph(relationTypeName, vreId, d3Graph, vertex, relationNames, depth, 1);
 
     return d3Graph;
   }
 
-  private void generateD3Graph(D3Graph d3Graph, Vertex vertex, List<String> relationNames,
+  private void generateD3Graph(String relationTypeName, String vreId, D3Graph d3Graph, Vertex vertex,
+                               List<String> relationNames,
                                int depth, int currentDepth) {
 
-    d3Graph.addNode(vertex);
-    vertex.edges(Direction.BOTH, relationNames.toArray(new String[relationNames.size()])).forEachRemaining(edge -> {
-      loadLinks(d3Graph, relationNames, depth, currentDepth, edge);
+    final Optional<Collection> sourceCollection = GraphReadUtils.getCollectionByVreId(vertex, mappings, vreId);
 
+    d3Graph.addNode(vertex, sourceCollection.get().getEntityTypeName());
+    vertex.edges(Direction.BOTH, relationNames.toArray(new String[relationNames.size()])).forEachRemaining(edge -> {
+      final Boolean isAccepted = edge.property(relationTypeName + "_accepted").isPresent() ?
+        (Boolean) edge.property(relationTypeName + "_accepted").value() : false;
+
+      final Boolean isLatest = edge.property("isLatest").isPresent() ?
+        (Boolean) edge.property("isLatest").value() : false;
+
+      if (isAccepted && isLatest) {
+        loadLinks(relationTypeName, vreId, d3Graph, relationNames, depth, currentDepth, edge);
+      }
     });
   }
 
-  private void loadLinks(D3Graph d3Graph, List<String> relationNames,
+  private void loadLinks(String relationTypeName, String vreId, D3Graph d3Graph, List<String> relationNames,
                          int depth, int currentDepth, Edge edge) {
 
     Vertex source = edge.inVertex();
     Vertex target = edge.outVertex();
-    d3Graph.addNode(source);
-    d3Graph.addNode(target);
-    d3Graph.addLink(edge, source, target);
+    final Optional<Collection> sourceCollection = GraphReadUtils.getCollectionByVreId(source, mappings, vreId);
+    final Optional<Collection> targetCollection = GraphReadUtils.getCollectionByVreId(target, mappings, vreId);
 
-    if (currentDepth < depth) {
-      generateD3Graph(d3Graph, source, relationNames, depth, currentDepth + 1);
-      generateD3Graph(d3Graph, target, relationNames, depth, currentDepth + 1);
+    if (sourceCollection.isPresent() && targetCollection.isPresent()) {
+      final String sourceEntityTypeName = sourceCollection.get().getEntityTypeName();
+      final String targetEntityTypeName = targetCollection.get().getEntityTypeName();
+      d3Graph.addNode(source, sourceEntityTypeName);
+      d3Graph.addNode(target, targetEntityTypeName);
+      d3Graph.addLink(edge, source, target, sourceEntityTypeName, targetEntityTypeName);
+
+      if (currentDepth < depth) {
+        generateD3Graph(relationTypeName, vreId, d3Graph, source, relationNames, depth, currentDepth + 1);
+        generateD3Graph(relationTypeName, vreId, d3Graph, target, relationNames, depth, currentDepth + 1);
+      }
     }
   }
 }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/Node.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/Node.java
@@ -1,6 +1,7 @@
 package nl.knaw.huygens.timbuctoo.graph;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.knaw.huygens.timbuctoo.model.GraphReadUtils;
 import nl.knaw.huygens.timbuctoo.model.PersonNames;
 import nl.knaw.huygens.timbuctoo.search.description.PropertyDescriptor;
 import nl.knaw.huygens.timbuctoo.search.description.property.PropertyDescriptorFactory;
@@ -9,6 +10,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +34,12 @@ public class Node {
   private String type;
   private String key;
 
-  public Node(Vertex vertex) throws IOException {
+  public Node(Vertex vertex, String entityTypeName) throws IOException {
     this.type = getVertexType(vertex);
-    this.key = this.type + "s/" + vertex.property("tim_id").value();
+
+    this.key = entityTypeName == null ? this.type + "s/" + vertex.property("tim_id").value() :
+      entityTypeName + "s/" + vertex.property("tim_id").value();
+
     if (!propertyDescriptors.containsKey(type)) {
       throw new IOException("type not supported: " + type);
     }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
@@ -237,7 +237,7 @@ public class TimbuctooV4 extends Application<TimbuctooConfiguration> {
     if (configuration.isAllowGremlinEndpoint()) {
       register(environment, new Gremlin(graphManager, vres));
     }
-    register(environment, new Graph(graphManager));
+    register(environment, new Graph(graphManager, vres));
     // Bulk upload
     UriHelper uriHelper = new UriHelper(configuration);
     UserPermissionChecker permissionChecker = new UserPermissionChecker(loggedInUserStore, authorizer);

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/v2/Graph.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/v2/Graph.java
@@ -4,6 +4,7 @@ import io.dropwizard.jersey.params.UUIDParam;
 import nl.knaw.huygens.timbuctoo.crud.NotFoundException;
 import nl.knaw.huygens.timbuctoo.graph.D3Graph;
 import nl.knaw.huygens.timbuctoo.graph.GraphService;
+import nl.knaw.huygens.timbuctoo.model.vre.Vres;
 import nl.knaw.huygens.timbuctoo.server.GraphWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +28,8 @@ public class Graph {
   private final GraphService graphService;
 
 
-  public Graph(GraphWrapper wrapper) {
-    this.graphService = new GraphService(wrapper);
+  public Graph(GraphWrapper wrapper, Vres mappings) {
+    this.graphService = new GraphService(wrapper, mappings);
   }
 
   @GET
@@ -36,7 +37,7 @@ public class Graph {
                       @QueryParam("depth") int depth, @QueryParam("types") List<String> relationNames) {
 
     try {
-      D3Graph result = graphService.get(collectionName.replaceAll("^ww", ""), id.get(), relationNames, depth);
+      D3Graph result = graphService.get(collectionName, id.get(), relationNames, depth);
       return Response.ok(result).build();
     } catch (NotFoundException e) {
       return Response.status(Response.Status.NOT_FOUND).entity(jsnO("message", jsn("not found"))).build();

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/D3GraphTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/D3GraphTest.java
@@ -43,12 +43,12 @@ public class D3GraphTest {
     Vertex mockVertex1 = mockVertex("1", "document", "document_title", "title1");
     Vertex mockVertex2 = mockVertex("2", "document", "document_title", "title2");
 
-    underTest.addNode(mockVertex1);
-    underTest.addNode(mockVertex2);
+    underTest.addNode(mockVertex1, null);
+    underTest.addNode(mockVertex2, null);
 
     assertThat(underTest.getNodes(), contains(
-            new Node(mockVertex1),
-            new Node(mockVertex2)
+            new Node(mockVertex1, null),
+            new Node(mockVertex2, null)
     ));
   }
 
@@ -57,11 +57,11 @@ public class D3GraphTest {
     D3Graph underTest = new D3Graph();
     Vertex mockVertex1 = mockVertex("1", "document", "document_title", "title1");
 
-    underTest.addNode(mockVertex1);
-    underTest.addNode(mockVertex1);
+    underTest.addNode(mockVertex1, null);
+    underTest.addNode(mockVertex1, null);
 
     assertThat(underTest.getNodes(), contains(
-            new Node(mockVertex1)
+            new Node(mockVertex1, null)
     ));
   }
 
@@ -71,11 +71,11 @@ public class D3GraphTest {
     Vertex mockVertex1 = mockVertex("1", "document", "document_title", "title1");
     Vertex mockVertex2 = mockVertex("2", "unsupported", "document_title", "title2");
 
-    underTest.addNode(mockVertex1);
-    underTest.addNode(mockVertex2);
+    underTest.addNode(mockVertex1, null);
+    underTest.addNode(mockVertex2, null);
 
     assertThat(underTest.getNodes(), contains(
-            new Node(mockVertex1)
+            new Node(mockVertex1, null)
     ));
   }
 
@@ -87,12 +87,12 @@ public class D3GraphTest {
     Vertex mockVertex3 = mockVertex("3", "document", "document_title", "title3");
 
     Edge mockEdge = mockEdge("someRelation");
-    underTest.addNode(mockVertex1);
-    underTest.addNode(mockVertex2);
-    underTest.addNode(mockVertex3);
+    underTest.addNode(mockVertex1, null);
+    underTest.addNode(mockVertex2, null);
+    underTest.addNode(mockVertex3, null);
 
-    underTest.addLink(mockEdge, mockVertex1, mockVertex2);
-    underTest.addLink(mockEdge, mockVertex1, mockVertex3);
+    underTest.addLink(mockEdge, mockVertex1, mockVertex2, null, null);
+    underTest.addLink(mockEdge, mockVertex1, mockVertex3, null, null);
 
     assertThat(underTest.getLinks(), contains(
             new Link(mockEdge, 0, 1),
@@ -107,11 +107,13 @@ public class D3GraphTest {
     Vertex mockVertex2 = mockVertex("2", "document", "document_title", "title2");
 
     Edge mockEdge = mockEdge("someRelation");
-    underTest.addNode(mockVertex1);
-    underTest.addNode(mockVertex2);
+    underTest.addNode(mockVertex1, null);
+    underTest.addNode(mockVertex2, null);
 
-    underTest.addLink(mockEdge, mockVertex1, mockVertex2);
-    underTest.addLink(mockEdge, mockVertex2, mockVertex1);
+    underTest.addLink(mockEdge, mockVertex1, mockVertex2, null,
+      null);
+    underTest.addLink(mockEdge, mockVertex2, mockVertex1, null,
+      null);
 
     assertThat(underTest.getLinks(), contains(
             new Link(mockEdge, 0, 1)
@@ -126,13 +128,16 @@ public class D3GraphTest {
     Vertex mockVertex3 = mockVertex("3", "unsupported", "document_title", "title3");
 
     Edge mockEdge = mockEdge("someRelation");
-    underTest.addNode(mockVertex1);
-    underTest.addNode(mockVertex2);
-    underTest.addNode(mockVertex3);
+    underTest.addNode(mockVertex1, null);
+    underTest.addNode(mockVertex2, null);
+    underTest.addNode(mockVertex3, null);
 
-    underTest.addLink(mockEdge, mockVertex1, mockVertex2);
-    underTest.addLink(mockEdge, mockVertex1, mockVertex3);
-    underTest.addLink(mockEdge, mockVertex3, mockVertex1);
+    underTest.addLink(mockEdge, mockVertex1, mockVertex2, null,
+      null);
+    underTest.addLink(mockEdge, mockVertex1, mockVertex3, null,
+      null);
+    underTest.addLink(mockEdge, mockVertex3, mockVertex1, null,
+      null);
 
 
     assertThat(underTest.getLinks(), contains(

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/NodeTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/NodeTest.java
@@ -39,42 +39,42 @@ public class NodeTest {
 
   @Test
   public void getLabelReturnsTheLabel() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.getLabel(), is(DOCUMENT_LABEL));
   }
 
   @Test
   public void getTypeReturnsTheType() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.getType(), is(TYPE));
   }
 
   @Test
   public void getKeyReturnsTheKey() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.getKey(), is(TYPE + "s/" + TIM_ID));
   }
 
   @Test
   public void equalsReturnsFalseWhenOtherIsNull() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.equals(null), is(false));
   }
 
   @Test
   public void equalsReturnsTrueWhenOtherHasTheSameMemoryReference() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.equals(underTest), is(true));
   }
 
   @Test
   public void equalsReturnsFalseWhenOtherIsNotANode() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.equals(new Object()), is(false));
 
@@ -82,8 +82,8 @@ public class NodeTest {
 
   @Test
   public void equalsReturnsTrueWhenOtherNodeHasTheSameKey() throws IOException {
-    Node underTest = new Node(mockDocumentVertex);
-    Node toCompare = new Node(mockDocumentVertex);
+    Node underTest = new Node(mockDocumentVertex, null);
+    Node toCompare = new Node(mockDocumentVertex, null);
 
     assertThat(underTest.equals(toCompare), is(true));
     assertThat(underTest == toCompare, is(false));
@@ -104,7 +104,7 @@ public class NodeTest {
     given(mockPersonVertex.value("wwperson_tempName")).willReturn(tempName);
     given(mockPersonVertex.keys()).willReturn(Sets.newHashSet("wwperson_tempName"));
 
-    Node underTest = new Node(mockPersonVertex);
+    Node underTest = new Node(mockPersonVertex, null);
 
     assertThat(underTest.getType(), is(type));
     assertThat(underTest.getKey(), is(type + "s/" + timId));
@@ -123,6 +123,6 @@ public class NodeTest {
     given(timIdProperty.value()).willReturn(timId);
     given(typesProperty.value()).willReturn("[\"" + type +  "\"]");
 
-    new Node(mockUnsupportedVertex);
+    new Node(mockUnsupportedVertex, null);
   }
 }


### PR DESCRIPTION
#### Context
The current graph resource does not filter edges, so the returned d3 graph is bogus.

#### Definition of done
This issue is considered delivered when:
The d3 graph resource returns only edges which are:
- from the own vre
- are accepted within the vre
- are the latest revision
