### PR TITLE
fix owl:sameAs for existing pairs.

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/rdf/SystemPropertyModifier.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/rdf/SystemPropertyModifier.java
@@ -1,9 +1,11 @@
 package nl.knaw.huygens.timbuctoo.rdf;
 
+import com.google.common.collect.Lists;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.shaded.jackson.databind.node.JsonNodeFactory;
 
 import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -11,6 +13,9 @@ import java.util.UUID;
  */
 public class SystemPropertyModifier {
 
+  public static final List<String> SYSTEM_PROPERTY_NAMES = Lists.newArrayList(
+    "rdfUri", "modified", "created", "types", "tim_id", "rdfAlternatives"
+  );
   private final JsonNodeFactory nodeFactory = JsonNodeFactory.instance;
   private final Clock clock;
 

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/rdf/tripleprocessor/SameAsTripleProcessor.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/rdf/tripleprocessor/SameAsTripleProcessor.java
@@ -21,9 +21,9 @@ public class SameAsTripleProcessor {
     Optional<Entity> object = database.findEntity(vreName, triple.getObject());
     Optional<Entity> subject = database.findEntity(vreName, triple.getSubject());
     if (object.isPresent() && subject.isPresent()) {
-      //FIXME: handle this case
-      //FIXME: handle the case where the same property is asserted for both same-as versions using different values
-      LOG.error("SameAs encountered, but the entities both already exist. This is not handled yet");
+      Entity objectEntity = object.get();
+      Entity subjectEntity = subject.get();
+      database.mergeObjectIntoSubjectEntity(vreName, subjectEntity, objectEntity);
     } else if (object.isPresent()) {
       database.addRdfSynonym(vreName, object.get(), triple.getSubject());
     } else if (subject.isPresent()) {

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/rdf/DatabaseTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/rdf/DatabaseTest.java
@@ -5,11 +5,13 @@ import nl.knaw.huygens.timbuctoo.server.TinkerpopGraphManager;
 import org.apache.jena.graph.Node;
 import org.apache.tinkerpop.gremlin.neo4j.process.traversal.LabelP;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -20,10 +22,12 @@ import static nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection.HAS_ARCH
 import static nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection.HAS_ENTITY_NODE_RELATION_NAME;
 import static nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection.HAS_ENTITY_RELATION_NAME;
 import static nl.knaw.huygens.timbuctoo.rdf.Database.RDF_URI_PROP;
+import static nl.knaw.huygens.timbuctoo.util.EdgeMatcher.likeEdge;
 import static nl.knaw.huygens.timbuctoo.util.OptionalPresentMatcher.present;
 import static nl.knaw.huygens.timbuctoo.util.TestGraphBuilder.newGraph;
 import static nl.knaw.huygens.timbuctoo.util.VertexMatcher.likeVertex;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
@@ -400,5 +404,124 @@ public class DatabaseTest {
     Optional<Collection> archetypeCollection = instance.findArchetypeCollection(node.getLocalName());
 
     assertThat(archetypeCollection, is(present()));
+  }
+
+  @Test
+  public void mergeObjectIntoSubjectEntityCopiesThePropertiesOfTheObjectIntoTheSubjectAndRemovesTheObject() {
+    TinkerpopGraphManager graphWrapper = newGraph()
+      .withVertex("entity1", v -> {
+        v.withProperty("a", "b").withProperty("c", "d").withProperty("modified", "x")
+         .withTimId("123");
+
+      })
+      .withVertex("entity2", v -> {
+        v.withProperty("a", "b").withProperty("c", "e").withProperty("f", "g").withProperty("modified", "y")
+         .withTimId("456");
+      })
+      .wrap();
+    final String vreName = "vreName";
+    final Vertex subjectVertex = graphWrapper.getGraph().traversal().V().has("tim_id", "123").next();
+    final Vertex objectVertex = graphWrapper.getGraph().traversal().V().has("tim_id", "456").next();
+    final Entity subject = new Entity(subjectVertex, null, null, null);
+    final Entity object = new Entity(objectVertex, null, null, null);
+    final Database instance = new Database(graphWrapper);
+
+    instance.mergeObjectIntoSubjectEntity(vreName, subject, object);
+    final Vertex result = graphWrapper.getGraph().traversal().V().next();
+
+    assertThat(graphWrapper.getGraph().traversal().V().has("tim_id", "456").hasNext(), equalTo(false));
+    assertThat(result, likeVertex()
+      .withProperty("a", "b")
+      .withProperty("c", "d")
+      .withProperty("f", "g")
+      .withProperty("modified", "x")
+      .withProperty("tim_id", "123")
+    );
+  }
+
+  @Test
+  public void mergeObjectIntoSubjectEntityCopiesTheOutgoingEdgesOfTheObjectIntoTheSubject() {
+    TinkerpopGraphManager graphWrapper = newGraph()
+      .withVertex("target1", v -> {
+        v.withTimId("789");
+      })
+      .withVertex("target2", v -> {
+        v.withTimId("abc");
+      })
+      .withVertex("entity1", v -> {
+        v.withTimId("123")
+          .withOutgoingRelation("relatedTo", "target1", edge -> edge.withRev(9));
+
+      })
+      .withVertex("entity2", v -> {
+        v.withTimId("456")
+          .withOutgoingRelation("relatedTo", "target1", edge ->
+            edge.withRev(1337)
+          )
+          .withOutgoingRelation("relatedTo", "target2", edge ->
+            edge.withRev(12)
+          );
+      })
+      .wrap();
+
+    final String vreName = "vreName";
+    final Vertex subjectVertex = graphWrapper.getGraph().traversal().V().has("tim_id", "123").next();
+    final Vertex objectVertex = graphWrapper.getGraph().traversal().V().has("tim_id", "456").next();
+    final Entity subject = new Entity(subjectVertex, null, null, null);
+    final Entity object = new Entity(objectVertex, null, null, null);
+    final Database instance = new Database(graphWrapper);
+
+    instance.mergeObjectIntoSubjectEntity(vreName, subject, object);
+
+    final List<Edge> edges = graphWrapper.getGraph().traversal().V().has("tim_id", "123").outE("relatedTo").toList();
+
+    assertThat(edges.size(), equalTo(2));
+    assertThat(edges, containsInAnyOrder(
+      likeEdge().withProperty("rev", 12),
+      likeEdge().withProperty("rev", 9)
+    ));
+  }
+
+  @Test
+  public void mergeObjectIntoSubjectEntityCopiesTheIncomingEdgesOfTheObjectIntoTheSubject() {
+    TinkerpopGraphManager graphWrapper = newGraph()
+      .withVertex("target1", v -> {
+        v.withTimId("789");
+      })
+      .withVertex("target2", v -> {
+        v.withTimId("abc");
+      })
+      .withVertex("entity1", v -> {
+        v.withTimId("123")
+          .withIncomingRelation("relatedTo", "target1", edge -> edge.withRev(9));
+
+      })
+      .withVertex("entity2", v -> {
+        v.withTimId("456")
+          .withIncomingRelation("relatedTo", "target1", edge ->
+            edge.withRev(1337)
+          )
+          .withIncomingRelation("relatedTo", "target2", edge ->
+            edge.withRev(12)
+          );
+      })
+      .wrap();
+
+    final String vreName = "vreName";
+    final Vertex subjectVertex = graphWrapper.getGraph().traversal().V().has("tim_id", "123").next();
+    final Vertex objectVertex = graphWrapper.getGraph().traversal().V().has("tim_id", "456").next();
+    final Entity subject = new Entity(subjectVertex, null, null, null);
+    final Entity object = new Entity(objectVertex, null, null, null);
+    final Database instance = new Database(graphWrapper);
+
+    instance.mergeObjectIntoSubjectEntity(vreName, subject, object);
+
+    final List<Edge> edges = graphWrapper.getGraph().traversal().V().has("tim_id", "123").inE("relatedTo").toList();
+
+    assertThat(edges.size(), equalTo(2));
+    assertThat(edges, containsInAnyOrder(
+      likeEdge().withProperty("rev", 12),
+      likeEdge().withProperty("rev", 9)
+    ));
   }
 }


### PR DESCRIPTION
#### Context

currently we interpret owl:sameAs as an alias for one and the same entity vertex. 

In some cases two entity vertices already exist before the sameAs statement is reached. In this case we want to merge the two entitty vertices into one (while acknowledging the risk of value conflicts for the same properties of the subject and object)


#### Definition of done
This issue is considered delivered when:
1. The properties and relations of the the vertex referenced by the object in the sameAs statement are copied into the vertex referenced by the subject
2. The vertex referenced by the object in the sameAs statement is dropped.


