### PR TITLE
Fix pids

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/logging/Logmarkers.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/logging/Logmarkers.java
@@ -7,4 +7,5 @@ public class Logmarkers {
   public static Marker databaseInvariant = MarkerFactory.getMarker("Database_invariant_not_upheld");
   public static Marker serviceUnavailable = MarkerFactory.getMarker("Service_unavailable");
   public static Marker configurationFailure = MarkerFactory.getMarker("Configuration_failure");
+  public static Marker migration = MarkerFactory.getMarker("Migration");
 }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
@@ -47,7 +47,8 @@ import nl.knaw.huygens.timbuctoo.server.databasemigration.FixDcarKeywordDisplayN
 import nl.knaw.huygens.timbuctoo.server.databasemigration.MakePidsAbsoluteUrls;
 import nl.knaw.huygens.timbuctoo.server.databasemigration.ScaffoldMigrator;
 import nl.knaw.huygens.timbuctoo.server.endpoints.RootEndpoint;
-import nl.knaw.huygens.timbuctoo.server.endpoints.legacy.LegacyApiRedirects;
+import nl.knaw.huygens.timbuctoo.server.endpoints.legacy.LegacySingleEntityRedirect;
+import nl.knaw.huygens.timbuctoo.server.endpoints.legacy.LegacyIndexRedirect;
 import nl.knaw.huygens.timbuctoo.server.endpoints.v2.Authenticate;
 import nl.knaw.huygens.timbuctoo.server.endpoints.v2.Graph;
 import nl.knaw.huygens.timbuctoo.server.endpoints.v2.Gremlin;
@@ -244,7 +245,8 @@ public class TimbuctooV4 extends Application<TimbuctooConfiguration> {
     register(environment, new Index(loggedInUserStore, crudServiceFactory, transactionEnforcer));
     register(environment, new SingleEntity(loggedInUserStore, crudServiceFactory, transactionEnforcer));
     register(environment, new WomenWritersEntityGet(crudServiceFactory, transactionEnforcer));
-    register(environment, new LegacyApiRedirects(uriHelper));
+    register(environment, new LegacySingleEntityRedirect(uriHelper));
+    register(environment, new LegacyIndexRedirect(uriHelper));
 
     if (configuration.isAllowGremlinEndpoint()) {
       register(environment, new Gremlin(graphManager, vres));

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
@@ -44,6 +44,7 @@ import nl.knaw.huygens.timbuctoo.security.JsonBasedUserStore;
 import nl.knaw.huygens.timbuctoo.security.LoggedInUserStore;
 import nl.knaw.huygens.timbuctoo.server.databasemigration.DatabaseMigration;
 import nl.knaw.huygens.timbuctoo.server.databasemigration.FixDcarKeywordDisplayNameMigration;
+import nl.knaw.huygens.timbuctoo.server.databasemigration.MakePidsAbsoluteUrls;
 import nl.knaw.huygens.timbuctoo.server.databasemigration.ScaffoldMigrator;
 import nl.knaw.huygens.timbuctoo.server.endpoints.RootEndpoint;
 import nl.knaw.huygens.timbuctoo.server.endpoints.legacy.LegacyApiRedirects;
@@ -168,6 +169,7 @@ public class TimbuctooV4 extends Application<TimbuctooConfiguration> {
     LinkedHashMap<String, DatabaseMigration> migrations = new LinkedHashMap<>();
 
     migrations.put("fix-dcarkeywords-displayname-migration", new FixDcarKeywordDisplayNameMigration());
+    migrations.put("fix-pids-migration", new MakePidsAbsoluteUrls());
     final UriHelper uriHelper = new UriHelper(configuration.getBaseUri());
 
     final TinkerpopGraphManager graphManager = new TinkerpopGraphManager(configuration, migrations);

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/databasemigration/MakePidsAbsoluteUrls.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/databasemigration/MakePidsAbsoluteUrls.java
@@ -1,0 +1,40 @@
+package nl.knaw.huygens.timbuctoo.server.databasemigration;
+
+import nl.knaw.huygens.timbuctoo.logging.Logmarkers;
+import nl.knaw.huygens.timbuctoo.server.GraphWrapper;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class MakePidsAbsoluteUrls implements DatabaseMigration {
+  private static final Logger LOG = getLogger(MakePidsAbsoluteUrls.class);
+
+  @Override
+  public void beforeMigration(GraphWrapper graphManager) {
+  }
+
+  @Override
+  public void execute(GraphWrapper graphWrapper) throws IOException {
+    Transaction tx = graphWrapper.getGraph().tx();
+    if (!tx.isOpen()) {
+      tx.open();
+    }
+
+    graphWrapper.getGraph().traversal()
+                .V()
+                .has("pid")
+                .filter(x -> !((String) x.get().value("pid")).startsWith("http://"))
+                .forEachRemaining(it -> {
+                  String orig = it.value("pid");
+                  String replacement = "http://hdl.handle.net/11240/" + orig;
+                  if (Math.random() < 0.1) {
+                    LOG.info(Logmarkers.migration, "Replacing " + orig + " with " + replacement);
+                  }
+                  it.property("pid", replacement);
+                });
+    tx.commit();
+  }
+}

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/legacy/LegacyIndexRedirect.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/legacy/LegacyIndexRedirect.java
@@ -1,0 +1,33 @@
+package nl.knaw.huygens.timbuctoo.server.endpoints.legacy;
+
+import io.dropwizard.jersey.params.UUIDParam;
+import nl.knaw.huygens.timbuctoo.server.UriHelper;
+import nl.knaw.huygens.timbuctoo.server.endpoints.v2.domain.Index;
+import nl.knaw.huygens.timbuctoo.server.endpoints.v2.domain.SingleEntity;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+/**
+ * This class redirects from API endpoints that are no longer supported, but whose urls are still cached by google
+ * or the handle server to their current counterparts.
+ */
+@Path("/domain/{collection}")
+public class LegacyIndexRedirect {
+
+  private final UriHelper uriHelper;
+
+  public LegacyIndexRedirect(UriHelper uriHelper) {
+    this.uriHelper = uriHelper;
+  }
+
+  @GET
+  public Response index(@PathParam("collection") String collectionName) {
+    return Response.status(301)
+                   .location(uriHelper.fromResourceUri(Index.makeUrl(collectionName)))
+                   .build();
+  }
+}

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/legacy/LegacySingleEntityRedirect.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/legacy/LegacySingleEntityRedirect.java
@@ -15,28 +15,20 @@ import javax.ws.rs.core.Response;
  * This class redirects from API endpoints that are no longer supported, but whose urls are still cached by google
  * or the handle server to their current counterparts.
  */
-public class LegacyApiRedirects {
+@Path("/domain/{collection}/{id}")
+public class LegacySingleEntityRedirect {
 
   private final UriHelper uriHelper;
 
-  public LegacyApiRedirects(UriHelper uriHelper) {
+  public LegacySingleEntityRedirect(UriHelper uriHelper) {
     this.uriHelper = uriHelper;
   }
 
-  @Path("/domain/{collection}/{id}")
   @GET
   public Response singleEntity(@PathParam("collection") String collectionName, @PathParam("id") UUIDParam id,
                                @QueryParam("rev") Integer rev) {
     return Response.status(301)
                    .location(uriHelper.fromResourceUri(SingleEntity.makeUrl(collectionName, id.get(), rev)))
-                   .build();
-  }
-
-  @Path("/domain/{collection}")
-  @GET
-  public Response index(@PathParam("collection") String collectionName) {
-    return Response.status(301)
-                   .location(uriHelper.fromResourceUri(Index.makeUrl(collectionName)))
                    .build();
   }
 }


### PR DESCRIPTION
# Context
Some "pid" properties were accidentally filled with only the handle UUID instead of the whole url. This bug has already been fixed, but we still needed to repair the wrong PIDs

# How to test

```
...SNIP
- INFO   Replacing 0e1dc3e0-5d4a-4a02-a7e0-1a7a66626571 with http://hdl.handle.net/11240/0e1dc3e0-5d4a-4a02-a7e0-1a7a66626571 [n.k.h.t.server.databasemigration.MakePidsAbsoluteUrls]
SNIP...
```
```
> g.V().properties("pid").count()
143288143288
> g.V().values("pid").filter({ it.get().startsWith("http://") }).count()
143288143288
```

Q.E.D.