### PR TITLE
make createEntity immutable

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/crud/JsonCrudService.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/crud/JsonCrudService.java
@@ -7,13 +7,13 @@ import nl.knaw.huygens.timbuctoo.database.NotFoundException;
 import nl.knaw.huygens.timbuctoo.database.TimbuctooActions;
 import nl.knaw.huygens.timbuctoo.database.converters.json.EntityToJsonMapper;
 import nl.knaw.huygens.timbuctoo.database.converters.json.JsonToEntityMapper;
-import nl.knaw.huygens.timbuctoo.database.dto.CreateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.CreateRelation;
 import nl.knaw.huygens.timbuctoo.database.dto.DataStream;
 import nl.knaw.huygens.timbuctoo.database.dto.ReadEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.UpdateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.UpdateRelation;
 import nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection;
+import nl.knaw.huygens.timbuctoo.database.dto.property.TimProperty;
 import nl.knaw.huygens.timbuctoo.model.vre.Vres;
 import nl.knaw.huygens.timbuctoo.security.AuthorizationException;
 import nl.knaw.huygens.timbuctoo.security.AuthorizationUnavailableException;
@@ -84,11 +84,11 @@ public class JsonCrudService {
   private UUID createEntity(Collection collection, ObjectNode input, String userId)
     throws IOException, AuthorizationException, AuthorizationUnavailableException {
 
-    CreateEntity createEntity = jsonToEntityMapper.newCreateEntity(collection, input);
+    List<TimProperty<?>> timProperties = jsonToEntityMapper.getDataProperties(collection, input);
 
     Optional<Collection> baseCollection = mappings.getCollectionForType(collection.getAbstractType());
 
-    UUID id = timDbAccess.createEntity(collection, baseCollection, createEntity, userId);
+    UUID id = timDbAccess.createEntity(collection, baseCollection, timProperties, userId);
 
     return id;
   }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/TimbuctooActions.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/TimbuctooActions.java
@@ -5,11 +5,13 @@ import nl.knaw.huygens.timbuctoo.database.dto.CreateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.CreateRelation;
 import nl.knaw.huygens.timbuctoo.database.dto.DataStream;
 import nl.knaw.huygens.timbuctoo.database.dto.EntityLookup;
+import nl.knaw.huygens.timbuctoo.database.dto.ImmutableCreateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.ImmutableEntityLookup;
 import nl.knaw.huygens.timbuctoo.database.dto.ReadEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.UpdateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.UpdateRelation;
 import nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection;
+import nl.knaw.huygens.timbuctoo.database.dto.property.TimProperty;
 import nl.knaw.huygens.timbuctoo.database.exceptions.RelationNotPossibleException;
 import nl.knaw.huygens.timbuctoo.model.Change;
 import nl.knaw.huygens.timbuctoo.model.vre.Vres;
@@ -48,14 +50,17 @@ public class TimbuctooActions {
     this.afterSuccessTaskExecutor = afterSuccessTaskExecutor;
   }
 
-  public UUID createEntity(Collection collection, Optional<Collection> baseCollection, CreateEntity createEntity,
-                           String userId)
+  public UUID createEntity(Collection collection, Optional<Collection> baseCollection,
+                           Iterable<TimProperty<?>> properties, String userId)
     throws AuthorizationUnavailableException, AuthorizationException, IOException {
     checkIfAllowedToWrite(userId, collection);
     UUID id = UUID.randomUUID();
-    createEntity.setId(id);
     Change created = createChange(userId);
-    createEntity.setCreated(created);
+    CreateEntity createEntity = ImmutableCreateEntity.builder()
+      .properties(properties)
+      .id(id)
+      .created(created)
+      .build();
 
     dataStoreOperations.createEntity(collection, baseCollection, createEntity);
 

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/converters/json/JsonToEntityMapper.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/converters/json/JsonToEntityMapper.java
@@ -2,7 +2,6 @@ package nl.knaw.huygens.timbuctoo.database.converters.json;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import nl.knaw.huygens.timbuctoo.database.dto.CreateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.UpdateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection;
 import nl.knaw.huygens.timbuctoo.database.dto.property.TimProperty;
@@ -23,11 +22,6 @@ public class JsonToEntityMapper {
 
   public static final Logger LOG = LoggerFactory.getLogger(JsonToEntityMapper.class);
 
-  public CreateEntity newCreateEntity(Collection collection, ObjectNode input) throws IOException {
-    List<TimProperty<?>> properties = getDataProperties(collection, input);
-    return new CreateEntity(properties);
-  }
-
   public UpdateEntity newUpdateEntity(Collection collection, UUID id, ObjectNode data)
     throws IOException {
     if (data.get("^rev") == null) {
@@ -43,7 +37,7 @@ public class JsonToEntityMapper {
   /**
    * Retrieve all the properties that contain client data.
    */
-  private List<TimProperty<?>> getDataProperties(Collection collection, ObjectNode input) throws IOException {
+  public List<TimProperty<?>> getDataProperties(Collection collection, ObjectNode input) throws IOException {
     JsonPropertyConverter converter = new JsonPropertyConverter(collection);
 
     Set<String> fieldNames = getDataFields(input);

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/dto/CreateEntity.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/dto/CreateEntity.java
@@ -2,36 +2,18 @@ package nl.knaw.huygens.timbuctoo.database.dto;
 
 import nl.knaw.huygens.timbuctoo.database.dto.property.TimProperty;
 import nl.knaw.huygens.timbuctoo.model.Change;
+import org.immutables.value.Value;
 
 import java.util.UUID;
 
 
-public class CreateEntity {
-  private final Iterable<TimProperty<?>> properties;
-  private UUID id;
-  private Change created;
+@Value.Immutable
+public interface CreateEntity {
 
-  public CreateEntity(Iterable<TimProperty<?>> properties) {
-    this.properties = properties;
-  }
+  Iterable<TimProperty<?>> getProperties();
 
-  public Iterable<TimProperty<?>> getProperties() {
-    return properties;
-  }
+  UUID getId();
 
-  public UUID getId() {
-    return id;
-  }
+  Change getCreated();
 
-  public void setId(UUID id) {
-    this.id = id;
-  }
-
-  public Change getCreated() {
-    return created;
-  }
-
-  public void setCreated(Change created) {
-    this.created = created;
-  }
 }

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/database/DataStoreOperationsTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/database/DataStoreOperationsTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static nl.knaw.huygens.timbuctoo.database.dto.CreateEntityStubs.withProperties;
 import static nl.knaw.huygens.timbuctoo.model.GraphReadUtils.getProp;
 import static nl.knaw.huygens.timbuctoo.model.properties.PropertyTypes.localProperty;
 import static nl.knaw.huygens.timbuctoo.util.EdgeMatcher.likeEdge;
@@ -58,9 +59,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 public class DataStoreOperationsTest {
@@ -114,16 +115,13 @@ public class DataStoreOperationsTest {
     List<TimProperty<?>> properties = Lists.newArrayList();
     properties.add(new StringProperty("prop1", "val1"));
     properties.add(new StringProperty("prop2", "val2"));
-    CreateEntity createEntity = new CreateEntity(properties);
-    UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    createEntity.setCreated(new Change(Instant.now().toEpochMilli(), "userId", null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
     assertThat(graphWrapper.getGraph()
                            .traversal().V()
-                           .has("tim_id", id.toString())
+                           .has("tim_id", createEntity.getId().toString())
                            .has("testthing_prop1", "val1")
                            .has("testthing_prop2", "val2")
                            .hasNext(),
@@ -137,16 +135,13 @@ public class DataStoreOperationsTest {
     Collection collection = vres.getCollection("testthings").get();
     DataStoreOperations instance = new DataStoreOperations(graphWrapper, mock(ChangeListener.class), null, vres);
     List<TimProperty<?>> properties = Lists.newArrayList();
-    CreateEntity createEntity = new CreateEntity(properties);
-    UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    createEntity.setCreated(new Change(Instant.now().toEpochMilli(), "userId", null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
     assertThat(graphWrapper.getGraph()
                            .traversal().V()
-                           .has("tim_id", id.toString())
+                           .has("tim_id", createEntity.getId().toString())
                            .has("rev", 1)
                            .hasNext(),
       is(true));
@@ -159,16 +154,13 @@ public class DataStoreOperationsTest {
     Collection collection = vres.getCollection("testthings").get();
     DataStoreOperations instance = new DataStoreOperations(graphWrapper, mock(ChangeListener.class), null, vres);
     List<TimProperty<?>> properties = Lists.newArrayList();
-    CreateEntity createEntity = new CreateEntity(properties);
-    UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    createEntity.setCreated(new Change(Instant.now().toEpochMilli(), "userId", null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
     assertThat(graphWrapper.getGraph()
                            .traversal().V()
-                           .has("tim_id", id.toString())
+                           .has("tim_id", createEntity.getId().toString())
                            .next().value("types"),
       allOf(containsString("testthing"), containsString("thing"))
     );
@@ -200,25 +192,22 @@ public class DataStoreOperationsTest {
     Collection collection = vres.getCollection("testthings").get();
     DataStoreOperations instance = new DataStoreOperations(graphWrapper, mock(ChangeListener.class), null, vres);
     List<TimProperty<?>> properties = Lists.newArrayList();
-    CreateEntity createEntity = new CreateEntity(properties);
-    UUID id = UUID.randomUUID();
-    createEntity.setId(id);
     String userId = "userId";
     long timeStamp = Instant.now().toEpochMilli();
-    createEntity.setCreated(new Change(timeStamp, userId, null));
+    CreateEntity createEntity = withProperties(properties, userId, timeStamp);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
     assertThat(graphWrapper.getGraph()
                            .traversal().V()
-                           .has("tim_id", id.toString())
+                           .has("tim_id", createEntity.getId().toString())
                            .next().value("created"),
       sameJSONAs(String.format("{\"timeStamp\": %s,\"userId\": \"%s\"}", timeStamp, userId))
     );
 
     assertThat(graphWrapper.getGraph()
                            .traversal().V()
-                           .has("tim_id", id.toString())
+                           .has("tim_id", createEntity.getId().toString())
                            .next().value("modified"),
       sameJSONAs(String.format("{\"timeStamp\": %s,\"userId\": \"%s\"}", timeStamp, userId))
     );
@@ -231,16 +220,19 @@ public class DataStoreOperationsTest {
     Collection collection = vres.getCollection("testthings").get();
     DataStoreOperations instance = new DataStoreOperations(graphWrapper, mock(ChangeListener.class), null, vres);
     List<TimProperty<?>> properties = Lists.newArrayList();
-    CreateEntity createEntity = new CreateEntity(properties);
     UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    String userId = "userId";
-    long timeStamp = Instant.now().toEpochMilli();
-    createEntity.setCreated(new Change(timeStamp, userId, null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
-    assertThat(graphWrapper.getGraph().traversal().V().has("tim_id", id.toString()).count().next(), is(2L));
+    assertThat(
+      graphWrapper.getGraph().traversal()
+        .V()
+        .has("tim_id", createEntity.getId().toString())
+        .count()
+        .next(),
+      is(2L)
+    );
   }
 
   @Test
@@ -251,17 +243,17 @@ public class DataStoreOperationsTest {
     ChangeListener changeListener = mock(ChangeListener.class);
     DataStoreOperations instance = new DataStoreOperations(graphWrapper, changeListener, null, vres);
     List<TimProperty<?>> properties = Lists.newArrayList();
-    CreateEntity createEntity = new CreateEntity(properties);
     UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    String userId = "userId";
-    long timeStamp = Instant.now().toEpochMilli();
-    createEntity.setCreated(new Change(timeStamp, userId, null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
     Vertex vertex =
-      graphWrapper.getGraph().traversal().V().has("tim_id", id.toString()).in("VERSION_OF").next();
+      graphWrapper.getGraph().traversal()
+        .V()
+        .has("tim_id", createEntity.getId().toString())
+        .in("VERSION_OF")
+        .next();
     verify(changeListener).onCreate(vertex);
   }
 
@@ -273,19 +265,15 @@ public class DataStoreOperationsTest {
     ChangeListener changeListener = mock(ChangeListener.class);
     DataStoreOperations instance = new DataStoreOperations(graphWrapper, changeListener, null, vres);
     List<TimProperty<?>> properties = Lists.newArrayList();
-    CreateEntity createEntity = new CreateEntity(properties);
     UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    String userId = "userId";
-    long timeStamp = Instant.now().toEpochMilli();
-    createEntity.setCreated(new Change(timeStamp, userId, null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
 
 
     assertThat(graphWrapper.getGraph()
                            .traversal().V()
-                           .has("tim_id", id.toString())
+                           .has("tim_id", createEntity.getId().toString())
                            .has("isLatest", true)
                            .count().next(),
       is(1L));
@@ -301,10 +289,7 @@ public class DataStoreOperationsTest {
     List<TimProperty<?>> properties = Lists.newArrayList();
     properties.add(new StringProperty("prop1", "val1"));
     properties.add(new StringProperty("unknowProp", "val2"));
-    CreateEntity createEntity = new CreateEntity(properties);
-    UUID id = UUID.randomUUID();
-    createEntity.setId(id);
-    createEntity.setCreated(new Change(Instant.now().toEpochMilli(), "userId", null));
+    CreateEntity createEntity = withProperties(properties);
 
     instance.createEntity(collection, Optional.empty(), createEntity);
   }

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/database/converters/json/JsonToEntityMapperTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/database/converters/json/JsonToEntityMapperTest.java
@@ -1,14 +1,15 @@
 package nl.knaw.huygens.timbuctoo.database.converters.json;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import nl.knaw.huygens.timbuctoo.database.dto.CreateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.UpdateEntity;
 import nl.knaw.huygens.timbuctoo.database.dto.dataset.Collection;
+import nl.knaw.huygens.timbuctoo.database.dto.property.TimProperty;
 import nl.knaw.huygens.timbuctoo.model.vre.vres.VresBuilder;
 import nl.knaw.huygens.timbuctoo.util.JsonBuilder;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 import static nl.knaw.huygens.timbuctoo.model.properties.PropertyTypes.localProperty;
@@ -38,9 +39,9 @@ public class JsonToEntityMapperTest {
     );
     JsonToEntityMapper instance = new JsonToEntityMapper();
 
-    CreateEntity createEntity = instance.newCreateEntity(collection, input);
+    List<TimProperty<?>> properties = instance.getDataProperties(collection, input);
 
-    assertThat(createEntity.getProperties(), containsInAnyOrder(
+    assertThat(properties, containsInAnyOrder(
       allOf(hasProperty("name", equalTo("name")), hasProperty("value", equalTo("Hans"))),
       allOf(hasProperty("name", equalTo("age")), hasProperty("value", equalTo("12")))
     ));
@@ -62,7 +63,7 @@ public class JsonToEntityMapperTest {
 
     JsonToEntityMapper instance = new JsonToEntityMapper();
 
-    instance.newCreateEntity(collection, input);
+    instance.getDataProperties(collection, input);
   }
 
   @Test(expected = IOException.class)
@@ -81,7 +82,7 @@ public class JsonToEntityMapperTest {
 
     JsonToEntityMapper instance = new JsonToEntityMapper();
 
-    instance.newCreateEntity(collection, input);
+    instance.getDataProperties(collection, input);
   }
 
   @Test
@@ -98,9 +99,9 @@ public class JsonToEntityMapperTest {
 
     JsonToEntityMapper instance = new JsonToEntityMapper();
 
-    CreateEntity createEntity = instance.newCreateEntity(collection, input);
+    List<TimProperty<?>> properties = instance.getDataProperties(collection, input);
 
-    assertThat(createEntity.getProperties(), not(containsInAnyOrder(
+    assertThat(properties, not(containsInAnyOrder(
       hasProperty("name", equalTo("_id")),
       hasProperty("name", equalTo("^rev")),
       hasProperty("name", equalTo("@type"))

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/database/dto/CreateEntityStubs.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/database/dto/CreateEntityStubs.java
@@ -1,0 +1,38 @@
+package nl.knaw.huygens.timbuctoo.database.dto;
+
+import nl.knaw.huygens.timbuctoo.database.dto.property.TimProperty;
+import nl.knaw.huygens.timbuctoo.model.Change;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class CreateEntityStubs {
+
+  public static CreateEntity dummy() {
+    return ImmutableCreateEntity.builder()
+      .properties(newArrayList())
+      .id(UUID.randomUUID())
+      .created(new Change(Instant.now().toEpochMilli(), "userId", null))
+      .build();
+  }
+
+  public static CreateEntity withProperties(List<TimProperty<?>> properties) {
+    return ImmutableCreateEntity.builder()
+      .properties(properties)
+      .id(UUID.randomUUID())
+      .created(new Change(Instant.now().toEpochMilli(), "userId", null))
+      .build();
+  }
+
+  public static CreateEntity withProperties(List<TimProperty<?>> properties, String userId, long timeStamp) {
+    return ImmutableCreateEntity.builder()
+      .properties(properties)
+      .id(UUID.randomUUID())
+      .created(new Change(timeStamp, userId, null))
+      .build();
+  }
+
+}


### PR DESCRIPTION
Before this commit createEntity was created by the JsonToEntityMapper
and then got extra properties from TimbuctooActions. To make the
dependency more clear and harder CreateEntity now can only be
constructed using all the information that DataStoreOperations requires