### PR TITLE
Cut Docker container size down to 315.8MB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM huygensing/timbuctoo:build-base
+FROM maven:3.3-jdk-8-alpine
 
 ENV BASE_URI=http://localhost:8080
 ENV TIMBUCTOO_SEARCH_URL=http://localhost:8082
@@ -10,13 +10,21 @@ RUN mkdir -p /data/database
 RUN echo "[]" > /data/auth/logins.json
 RUN echo "[]" > /data/auth/users.json
 
-COPY ./ContractDiff ./ContractDiff
-COPY ./HttpCommand ./HttpCommand
-COPY ./security-client-agnostic ./security-client-agnostic
-COPY ./timbuctoo-test-services ./timbuctoo-test-services
-COPY ./timbuctoo-instancev4/src ./timbuctoo-instancev4/src
-COPY ./timbuctoo-instancev4/pom.xml ./timbuctoo-instancev4/pom.xml
+# First copy the POMs and fetch the dependencies.
+# As long as the POMs don't change, the dependencies will be cached.
 COPY ./pom.xml ./pom.xml
+COPY ./ContractDiff/pom.xml ./ContractDiff/pom.xml
+COPY ./HttpCommand/pom.xml ./HttpCommand/pom.xml
+COPY ./security-client-agnostic/pom.xml ./security-client-agnostic/pom.xml
+COPY ./timbuctoo-test-services/pom.xml ./timbuctoo-test-services/pom.xml
+COPY ./timbuctoo-instancev4/pom.xml ./timbuctoo-instancev4/pom.xml
+RUN mvn dependency:resolve-plugins
+
+COPY ./ContractDiff/src ./ContractDiff/src
+COPY ./HttpCommand/src ./HttpCommand/src
+COPY ./security-client-agnostic/src ./security-client-agnostic/src
+COPY ./timbuctoo-test-services/src ./timbuctoo-test-services/src
+COPY ./timbuctoo-instancev4/src ./timbuctoo-instancev4/src
 
 # FIXME: do a maven install and then run appassembler with generateRepository=false and specify /root/.m2 as the REPO
 # variable


### PR DESCRIPTION
* Uses Alpine Linux for smaller base image.
* Fetches dependencies in a separate step to get them cached.

With the current setup (using huygensing/timbuctoo:build-base as the base image), the image size is 1.1GB.