### PR TITLE
Make quadratic-time D3Graph construction linear

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
@@ -26,21 +26,25 @@ public class D3Graph {
     try {
       nodeIndex.putIfAbsent(new Node(vertex, entityTypeName), nodeIndex.size());
     } catch (IOException e) {
-      LOG.debug("Node not added because " + e.getMessage());
+      LOG.error("Node not added because " + e.getMessage());
     }
   }
 
   public void addLink(Edge edge, Vertex source, Vertex target, String sourceTypeName, String targetTypeName) {
     try {
-      Node srcNode = new Node(source, sourceTypeName);
-      Node tgtNode = new Node(target, targetTypeName);
-      // XXX The getOrDefault simulates the behavior of the previously used ArrayList::indexOf method.
-      // Throw an exception instead?
-      Link link = new Link(edge, nodeIndex.getOrDefault(srcNode, -1), nodeIndex.getOrDefault(tgtNode, -1));
-
-      links.add(link);
+      Integer sourceNode = nodeIndex.get(new Node(source, sourceTypeName));
+      Integer targetNode = nodeIndex.get(new Node(target, targetTypeName));
+      if (sourceNode == null) {
+        LOG.error("Link for edge {} was added, but the source vertex {} was not", edge.id(), source.id());
+      }
+      if (targetNode == null) {
+        LOG.error("Link for edge {} was added, but the target vertex {} was not", edge.id(), target.id());
+      }
+      if (sourceNode != null && targetNode != null) {
+        links.add(new Link(edge, sourceNode, targetNode));
+      }
     } catch (IOException e) {
-      LOG.debug("Link not added because " + e.getMessage());
+      LOG.error("Link not added because " + e.getMessage());
     }
   }
 

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class D3Graph {
-  public static final Logger LOG = LoggerFactory.getLogger(GraphService.class);
+  public static final Logger LOG = LoggerFactory.getLogger(D3GraphGeneratorService.class);
 
   // These are linked hash tables because some of the tests rely on the order of
   // their iterators. Is that necessary?

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3Graph.java
@@ -1,63 +1,62 @@
 package nl.knaw.huygens.timbuctoo.graph;
 
-import com.google.common.collect.Lists;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class D3Graph {
   public static final Logger LOG = LoggerFactory.getLogger(GraphService.class);
 
-  private final List<Node> nodes;
-  private final List<Link> links;
-
-  public D3Graph() {
-    nodes = Lists.newArrayList();
-    links = Lists.newArrayList();
-  }
+  // These are linked hash tables because some of the tests rely on the order of
+  // their iterators. Is that necessary?
+  private final LinkedHashMap<Node, Integer> nodeIndex = new LinkedHashMap<>();
+  private final LinkedHashSet<Link> links = new LinkedHashSet<>();
 
   public void addNode(Vertex vertex, String entityTypeName) {
     try {
-      Node node = new Node(vertex, entityTypeName);
-
-      if (!nodes.contains(node)) {
-        nodes.add(node);
-      }
-
+      nodeIndex.putIfAbsent(new Node(vertex, entityTypeName), nodeIndex.size());
     } catch (IOException e) {
-      LOG.debug("Node not added because " +  e.getMessage());
+      LOG.debug("Node not added because " + e.getMessage());
     }
   }
 
   public void addLink(Edge edge, Vertex source, Vertex target, String sourceTypeName, String targetTypeName) {
     try {
-      Link link = new Link(edge, nodes.indexOf(new Node(source, sourceTypeName)), nodes.indexOf(new Node(target,
-        targetTypeName)));
-      if (!links.contains(link)) {
-        links.add(link);
-      }
+      Node srcNode = new Node(source, sourceTypeName);
+      Node tgtNode = new Node(target, targetTypeName);
+      // XXX The getOrDefault simulates the behavior of the previously used ArrayList::indexOf method.
+      // Throw an exception instead?
+      Link link = new Link(edge, nodeIndex.getOrDefault(srcNode, -1), nodeIndex.getOrDefault(tgtNode, -1));
+
+      links.add(link);
     } catch (IOException e) {
       LOG.debug("Link not added because " + e.getMessage());
     }
   }
 
   public List<Node> getNodes() {
-    return nodes;
+    return nodeIndex.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toList());
   }
 
-  public List<Link> getLinks() {
-    return links;
+  public Collection<Link> getLinks() {
+    return Collections.unmodifiableSet(links);
   }
 
   @Override
   public String toString() {
     return "D3Graph{" +
-            "nodes=" + nodes +
-            ", links=" + links +
-            '}';
+      "nodes=" + getNodes() +
+      ", links=" + getLinks() +
+      '}';
   }
 }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3GraphGeneratorService.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/D3GraphGeneratorService.java
@@ -17,13 +17,13 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class GraphService {
+public class D3GraphGeneratorService {
 
   private static final int MAX_LINKS_PER_NODE = 50;
   private final GraphWrapper graphWrapper;
   private Vres mappings;
 
-  public GraphService(GraphWrapper wrapper, Vres mappings) {
+  public D3GraphGeneratorService(GraphWrapper wrapper, Vres mappings) {
     this.graphWrapper = wrapper;
     this.mappings = mappings;
   }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/Link.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/Link.java
@@ -3,6 +3,8 @@ package nl.knaw.huygens.timbuctoo.graph;
 
 import org.apache.tinkerpop.gremlin.structure.Edge;
 
+import java.util.Objects;
+
 public class Link {
   private int source;
   private int target;
@@ -45,6 +47,13 @@ public class Link {
     return otherLink.getType().equals(type) && (
         (otherLink.getSource() == source && otherLink.getTarget() == target) ||
         (otherLink.getSource() == target && otherLink.getTarget() == source));
+  }
+
+  @Override
+  public int hashCode() {
+    // Hash function that is symmetric in {source, target}.
+    // XXX sort source and target in the constructor instead?
+    return Objects.hash(source ^ target, type);
   }
 
   @Override

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/Node.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/graph/Node.java
@@ -79,6 +79,11 @@ public class Node {
   }
 
   @Override
+  public int hashCode() {
+    return key.hashCode();
+  }
+
+  @Override
   public String toString() {
     return "Node{" +
             "label='" + label + '\'' +

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/v2/Graph.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/v2/Graph.java
@@ -3,7 +3,7 @@ package nl.knaw.huygens.timbuctoo.server.endpoints.v2;
 import io.dropwizard.jersey.params.UUIDParam;
 import nl.knaw.huygens.timbuctoo.core.NotFoundException;
 import nl.knaw.huygens.timbuctoo.graph.D3Graph;
-import nl.knaw.huygens.timbuctoo.graph.GraphService;
+import nl.knaw.huygens.timbuctoo.graph.D3GraphGeneratorService;
 import nl.knaw.huygens.timbuctoo.model.vre.Vres;
 import nl.knaw.huygens.timbuctoo.server.GraphWrapper;
 import org.slf4j.Logger;
@@ -25,11 +25,11 @@ import static nl.knaw.huygens.timbuctoo.util.JsonBuilder.jsnO;
 @Produces(APPLICATION_JSON)
 public class Graph {
   public static final Logger LOG = LoggerFactory.getLogger(Graph.class);
-  private final GraphService graphService;
+  private final D3GraphGeneratorService d3GraphGeneratorService;
 
 
   public Graph(GraphWrapper wrapper, Vres mappings) {
-    this.graphService = new GraphService(wrapper, mappings);
+    this.d3GraphGeneratorService = new D3GraphGeneratorService(wrapper, mappings);
   }
 
   @GET
@@ -37,7 +37,7 @@ public class Graph {
                       @QueryParam("depth") int depth, @QueryParam("types") List<String> relationNames) {
 
     try {
-      D3Graph result = graphService.get(collectionName, id.get(), relationNames, depth);
+      D3Graph result = d3GraphGeneratorService.get(collectionName, id.get(), relationNames, depth);
       return Response.ok(result).build();
     } catch (NotFoundException e) {
       return Response.status(Response.Status.NOT_FOUND).entity(jsnO("message", jsn("not found"))).build();

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/D3GraphGeneratorServiceTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/D3GraphGeneratorServiceTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-public class GraphServiceTest {
+public class D3GraphGeneratorServiceTest {
 
 
   private static final String RELATION_NAME = "relationName";
@@ -147,7 +147,7 @@ public class GraphServiceTest {
     );
 
     GraphWrapper graphWrapper = createGraphWrapper(graph);
-    GraphService underTest = new GraphService(graphWrapper, HuygensIng.mappings);
+    D3GraphGeneratorService underTest = new D3GraphGeneratorService(graphWrapper, HuygensIng.mappings);
     D3Graph result = underTest.get(
             "wwperson", UUID.fromString(THE_UUID), Lists.newArrayList(RELATION_NAME, RELATION_NAME_2), 2);
 

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/GraphServiceTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/GraphServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -141,8 +142,9 @@ public class GraphServiceTest {
     List<Vertex> vertices = graph.traversal().V()
                                  .has("wwperson_tempName")
                                  .asAdmin().clone().toList();
-    Collections.sort(vertices, (vertexA, vertexB) -> ((String) vertexA.property("wwperson_tempName").value())
-            .compareTo((String) vertexB.property("wwperson_tempName").value()));
+    Collections.sort(vertices,
+      Comparator.comparing(vertexA -> ((String) vertexA.property("wwperson_tempName").value()))
+    );
 
     GraphWrapper graphWrapper = createGraphWrapper(graph);
     GraphService underTest = new GraphService(graphWrapper, HuygensIng.mappings);

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/GraphServiceTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/graph/GraphServiceTest.java
@@ -167,12 +167,13 @@ public class GraphServiceTest {
     ));
   }
 
-  private int getIndex(List<Node> nodes, String key) {
-    for (int i = 0; i < nodes.size(); i++) {
-      final Node node = nodes.get(i);
+  private int getIndex(java.util.Collection<Node> nodes, String key) {
+    int idx = 0;
+    for (Node node : nodes) {
       if (node.getKey().equals("wwpersons/" + key)) {
-        return i;
+        return idx;
       }
+      idx++;
     }
     return -1;
   }


### PR DESCRIPTION
The class D3Graph takes quadratic time to construct a graph in memory.

Comments indicate where I'm simulating the current behavior without knowing whether compatibility is a concern.