### PR TITLE
Implement resourcesync import

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/tinkerpop/TinkerPopOperations.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/database/tinkerpop/TinkerPopOperations.java
@@ -660,11 +660,11 @@ public class TinkerPopOperations implements DataStoreOperations {
         if (customDescriptors.containsKey(collectionName)) {
           displayName = customDescriptors.get(collectionName).get(vertex);
         } else {
-          displayName = (String) traversal.V(vertex.id()).union(collection.getDisplayName().traversalRaw()).next()
+          displayName = traversal.V(vertex.id()).union(collection.getDisplayName().traversalJson()).next()
             .getOrElseGet(e -> {
               LOG.error("Displayname generation for vertix with id " + vertex.id() + " failed", e);
-              return "#Error#";
-            });
+              return jsn("#Error#");
+            }).asText();
         }
         return QuickSearchResult.create(
           displayName,

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooConfiguration.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooConfiguration.java
@@ -64,6 +64,9 @@ public class TimbuctooConfiguration extends Configuration implements ActiveMQCon
   @NotNull
   @Valid
   private ActiveMQConfig activeMq;
+
+  private Optional<URI> userRedirectUrl = Optional.empty();
+
   @JsonProperty
   @NotNull
   private PersistenceManagerFactory persistenceManager;
@@ -198,5 +201,14 @@ public class TimbuctooConfiguration extends Configuration implements ActiveMQCon
 
   public WebhookFactory getWebhooks() {
     return webhooks;
+  }
+
+  public Optional<URI> getUserRedirectUrl() {
+    return userRedirectUrl;
+  }
+
+  @JsonProperty
+  private void setUserRedirectUrl(String userRedirectUrl) {
+    this.userRedirectUrl = Optional.of(URI.create(userRedirectUrl));
   }
 }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/TimbuctooV4.java
@@ -232,7 +232,7 @@ public class TimbuctooV4 extends Application<TimbuctooConfiguration> {
     );
 
     // register REST endpoints
-    register(environment, new RootEndpoint(uriHelper));
+    register(environment, new RootEndpoint(uriHelper, configuration.getUserRedirectUrl()));
     register(environment, new JsEnv(configuration));
     register(environment, new Authenticate(securityConfig.getLoggedInUsers(environment)));
     register(environment, new Me(securityConfig.getLoggedInUsers(environment)));

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/databasemigration/ScaffoldMigrator.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/databasemigration/ScaffoldMigrator.java
@@ -40,7 +40,7 @@ public class ScaffoldMigrator {
                 collection
                   .withDescription("People with at least a name, birthdate and birthplace.")
                   .withDisplayName(localProperty("person_names", defaultFullPersonNameConverter))
-                  .withProperty("names", localProperty("names", personNames))
+                  .withProperty("names", localProperty("person_names", personNames))
                   .withProperty("gender", localProperty("person_gender"))
                   .withProperty("birthDate", localProperty("person_birthDate", datable))
                   .withProperty("deathDate", localProperty("person_deathDate", datable))

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/RootEndpoint.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/server/endpoints/RootEndpoint.java
@@ -8,19 +8,24 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Optional;
 
 @Path("/")
 public class RootEndpoint {
 
   private final UriHelper uriHelper;
+  private final Optional<URI> userRedirectUrl;
 
-  public RootEndpoint(UriHelper uriHelper) {
+  public RootEndpoint(UriHelper uriHelper, Optional<URI> userRedirectUrl) {
     this.uriHelper = uriHelper;
+    this.userRedirectUrl = userRedirectUrl;
   }
 
   @GET
   @Produces(MediaType.TEXT_HTML)
   public Response getHomepage() {
-    return Response.temporaryRedirect(uriHelper.fromResourceUri(URI.create("/static/upload/"))).build();
+    URI url = userRedirectUrl
+      .orElseGet(() -> uriHelper.fromResourceUri(URI.create("/static/upload/")));
+    return Response.temporaryRedirect(url).build();
   }
 }


### PR DESCRIPTION
todo

- [x] make resourcesync discovery use the full url instead of the base64decode of the directory
- [ ] try to make resourcesync discovery faster. I think it browses all capability lists, while for our usecase it probably only needs to browse to initial resource list
