### PR TITLE
make json-ld identical to graphql schema

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/graphql/GraphQlTypesContainer.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/graphql/GraphQlTypesContainer.java
@@ -85,6 +85,10 @@ public class GraphQlTypesContainer {
         .name("value")
         .type(nonNull(Scalars.GraphQLString))
       )
+      .field(newFieldDefinition()
+        .name("type")
+        .type(nonNull(Scalars.GraphQLString))
+      )
       .typeResolver(valueTypeResolver)
       .build();
   }
@@ -165,6 +169,10 @@ public class GraphQlTypesContainer {
         .withInterface(this.valueInterface)
         .field(newFieldDefinition()
           .name("value")
+          .type(nonNull(Scalars.GraphQLString))
+        )
+        .field(newFieldDefinition()
+          .name("type")
           .type(nonNull(Scalars.GraphQLString))
         )
         .build();

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/graphql/serializable/SerializerExecutionStrategy.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/graphql/serializable/SerializerExecutionStrategy.java
@@ -16,6 +16,7 @@ import nl.knaw.huygens.timbuctoo.v5.graphql.datafetchers.dto.PaginatedList;
 import nl.knaw.huygens.timbuctoo.v5.graphql.datafetchers.dto.SubjectReference;
 import nl.knaw.huygens.timbuctoo.v5.graphql.datafetchers.dto.TypedValue;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Entity;
+import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionValue;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.PredicateInfo;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.QueryContainer;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Serializable;
@@ -148,7 +149,7 @@ public class SerializerExecutionStrategy extends SimpleExecutionStrategy {
         if (entry.getValue() == null || entry.getValue() instanceof Serializable) {
           copy.put(entry.getKey(), (Serializable) entry.getValue());
         } else {
-          copy.put(entry.getKey(), Value.fromRawJavaType(entry.getValue()));
+          copy.put(entry.getKey(), GraphqlIntrospectionValue.fromRawJavaType(entry.getValue()));
         }
       }
 

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/dto/GraphqlIntrospectionValue.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/dto/GraphqlIntrospectionValue.java
@@ -1,0 +1,30 @@
+package nl.knaw.huygens.timbuctoo.v5.serializable.dto;
+
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Represents a leaf node that contains the actual data. In the graphql query it's the object that is represented by
+ * {value}
+ */
+@org.immutables.value.Value.Immutable
+public interface GraphqlIntrospectionValue extends RdfData {
+  Logger LOG = getLogger(GraphqlIntrospectionValue.class);
+
+  Object getValue();
+
+  static GraphqlIntrospectionValue create(Object value) {
+    return ImmutableGraphqlIntrospectionValue.builder()
+      .value(value)
+      .build();
+  }
+
+  static GraphqlIntrospectionValue fromRawJavaType(Object value) {
+    if (value == null) {
+      return null;
+    } else {
+      return create(value);
+    }
+  }
+}

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/Dispatcher.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/Dispatcher.java
@@ -3,6 +3,7 @@ package nl.knaw.huygens.timbuctoo.v5.serializable.serializations;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Entity;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionList;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionObject;
+import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionValue;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Serializable;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.SerializableList;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Value;
@@ -21,6 +22,8 @@ public abstract class Dispatcher<T> {
 
   public abstract void handleGraphqlList(GraphqlIntrospectionList list, T context) throws IOException;
 
+  public abstract void handleGraphqlValue(GraphqlIntrospectionValue object, T context) throws IOException;
+
   public abstract void handleValue(Value object, T context) throws IOException;
 
   public void dispatch(Serializable entry, T context) throws IOException {
@@ -34,6 +37,8 @@ public abstract class Dispatcher<T> {
       handleGraphqlObject((GraphqlIntrospectionObject) entry, context);
     } else if (entry instanceof GraphqlIntrospectionList) {
       handleGraphqlList((GraphqlIntrospectionList) entry, context);
+    } else if (entry instanceof GraphqlIntrospectionValue) {
+      handleGraphqlValue((GraphqlIntrospectionValue) entry, context);
     } else if (entry  == null) {
       handleNull(context);
     } else {

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/base/CollectionsOfEntitiesSerialization.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/base/CollectionsOfEntitiesSerialization.java
@@ -6,6 +6,7 @@ import nl.knaw.huygens.timbuctoo.v5.serializable.Serialization;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Entity;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionList;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionObject;
+import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionValue;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.PredicateInfo;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Serializable;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.SerializableList;
@@ -93,6 +94,9 @@ public abstract class CollectionsOfEntitiesSerialization implements Serializatio
 
     @Override
     public void handleGraphqlList(GraphqlIntrospectionList list, Setter context) throws IOException { }
+
+    @Override
+    public void handleGraphqlValue(GraphqlIntrospectionValue object, Setter context) throws IOException { }
 
     @Override
     public void handleNull(Setter context) throws IOException { }

--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/base/FlatTableSerialization.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/base/FlatTableSerialization.java
@@ -6,6 +6,7 @@ import nl.knaw.huygens.timbuctoo.v5.serializable.Serialization;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.Entity;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionList;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionObject;
+import nl.knaw.huygens.timbuctoo.v5.serializable.dto.GraphqlIntrospectionValue;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.PredicateInfo;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.QueryContainer;
 import nl.knaw.huygens.timbuctoo.v5.serializable.dto.RdfData;
@@ -176,6 +177,9 @@ public abstract class FlatTableSerialization implements Serialization {
     }
 
     @Override
+    public void handleGraphqlValue(GraphqlIntrospectionValue object, TocItem context) throws IOException { }
+
+    @Override
     public void handleValue(Value object, TocItem tocItem) throws IOException {
 
     }
@@ -231,6 +235,11 @@ public abstract class FlatTableSerialization implements Serialization {
     public void handleGraphqlList(GraphqlIntrospectionList list, Tuple<TocItem, List<Value>> context)
       throws IOException {
 
+    }
+
+    @Override
+    public void handleGraphqlValue(GraphqlIntrospectionValue object, Tuple<TocItem, List<Value>> context)
+      throws IOException {
     }
 
     @Override

--- a/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/JsonLdSerializationTest.java
+++ b/timbuctoo-instancev4/src/test/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/JsonLdSerializationTest.java
@@ -21,49 +21,112 @@ public class JsonLdSerializationTest {
       "    \"Persons\" : [ { }, {\n" +
       "      \"@id\" : \"http://example.com/1\",\n" +
       "      \"@type\" : \"http://example.com/Person\",\n" +
-      "      \"a\" : 1,\n" +
+      "      \"a\" : {\n" +
+      "        \"type\" : \"http://www.w3.org/2001/XMLSchema#int\",\n" +
+      "        \"value\" : \"1\"\n" +
+      "      },\n" +
       "      \"b\" : [ {\n" +
       "        \"prevCursor\" : \"next\"\n" +
       "      }, {\n" +
       "        \"@id\" : \"http://example.com/11\",\n" +
       "        \"@type\" : \"http://example.com/SubItem\",\n" +
-      "        \"c\" : \"2\",\n" +
-      "        \"d\" : [ { }, \"3\", \"4\", null ]\n" +
+      "        \"c\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"2\"\n" +
+      "        },\n" +
+      "        \"d\" : [ { }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"3\"\n" +
+      "        }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"4\"\n" +
+      "        }, null ]\n" +
       "      }, {\n" +
       "        \"@id\" : \"http://example.com/12\",\n" +
       "        \"@type\" : \"http://example.com/SubItem\",\n" +
-      "        \"c\" : \"5\",\n" +
-      "        \"d\" : [ { }, \"6\", \"7\" ]\n" +
+      "        \"c\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"5\"\n" +
+      "        },\n" +
+      "        \"d\" : [ { }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"6\"\n" +
+      "        }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"7\"\n" +
+      "        } ]\n" +
       "      } ]\n" +
       "    }, {\n" +
       "      \"@id\" : \"http://example.com/2\",\n" +
       "      \"@type\" : \"http://example.com/Person\",\n" +
-      "      \"a\" : \"8\",\n" +
+      "      \"a\" : {\n" +
+      "        \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "        \"value\" : \"8\"\n" +
+      "      },\n" +
       "      \"b\" : [ { }, {\n" +
       "        \"@id\" : \"http://example.com/11\",\n" +
       "        \"@type\" : \"http://example.com/SubItem\",\n" +
-      "        \"c\" : \"9\",\n" +
-      "        \"d\" : [ { }, 10, \"11\" ]\n" +
+      "        \"c\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"9\"\n" +
+      "        },\n" +
+      "        \"d\" : [ { }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#int\",\n" +
+      "          \"value\" : \"10\"\n" +
+      "        }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"11\"\n" +
+      "        } ]\n" +
       "      }, {\n" +
       "        \"@id\" : \"http://example.com/12\",\n" +
       "        \"@type\" : \"http://example.com/SubItem\",\n" +
-      "        \"c\" : \"12\",\n" +
-      "        \"d\" : [ { }, 13.0, \"14\" ]\n" +
+      "        \"c\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"12\"\n" +
+      "        },\n" +
+      "        \"d\" : [ { }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#double\",\n" +
+      "          \"value\" : \"13.0\"\n" +
+      "        }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"14\"\n" +
+      "        } ]\n" +
       "      }, {\n" +
       "        \"@id\" : \"http://example.com/13\",\n" +
       "        \"@type\" : \"http://example.com/SubItem\",\n" +
-      "        \"c\" : \"15\",\n" +
-      "        \"d\" : [ { }, \"16\", \"17\", \"18\" ]\n" +
+      "        \"c\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"15\"\n" +
+      "        },\n" +
+      "        \"d\" : [ { }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"16\"\n" +
+      "        }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"17\"\n" +
+      "        }, {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"18\"\n" +
+      "        } ]\n" +
       "      } ]\n" +
       "    }, {\n" +
       "      \"@id\" : \"http://example.com/3\",\n" +
       "      \"@type\" : \"http://example.com/Person\",\n" +
-      "      \"a\" : \"19\",\n" +
+      "      \"a\" : {\n" +
+      "        \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "        \"value\" : \"19\"\n" +
+      "      },\n" +
       "      \"b\" : {\n" +
       "        \"@id\" : \"http://example.com/21\",\n" +
       "        \"@type\" : \"http://example.com/OtherSubItem\",\n" +
-      "        \"e\" : \"20\",\n" +
-      "        \"f\" : \"21\"\n" +
+      "        \"e\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"20\"\n" +
+      "        },\n" +
+      "        \"f\" : {\n" +
+      "          \"type\" : \"http://www.w3.org/2001/XMLSchema#string\",\n" +
+      "          \"value\" : \"21\"\n" +
+      "        }\n" +
       "      }\n" +
       "    } ]\n" +
       "  },\n" +
@@ -72,6 +135,8 @@ public class JsonLdSerializationTest {
       "      \"@id\" : \"@graph\",\n" +
       "      \"@container\" : \"@index\"\n" +
       "    },\n" +
+      "    \"value\" : \"@value\",\n" +
+      "    \"type\" : \"@type\",\n" +
       "    \"a\" : \"http://example.org/b\",\n" +
       "    \"b\" : {\n" +
       "      \"@reverse\" : \"http://example.org/b\"\n" +


### PR DESCRIPTION
The graphql schema contains a {value} object because values cannot be
part of a union type. The generated json-ld simplified these objects for
known json types (string, integer, number etc). This change marks
graphql introspection values as a different categorie from rdf values so
that we can generate simple json values for introspected graphql types
and expanded objects for all rdf types. So a query for `{value}` will
return and object with a value key.