### PR TITLE
Fix class should use its own class for Logger

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/base/FlatTableSerialization.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/serializable/serializations/base/FlatTableSerialization.java
@@ -28,7 +28,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 public abstract class FlatTableSerialization implements Serialization {
   public static final String SEPARATOR = ".";
-  private static final Logger LOG = getLogger(CsvSerialization.class);
+  private static final Logger LOG = getLogger(FlatTableSerialization.class);
 
   @Override
   public void serialize(SerializableResult data) throws IOException {


### PR DESCRIPTION
The abstract base class FlatTableSerialization used one of its concrete
implementation classes (CsvSerialization.class) for the construction of
its Logger.

This fix makes it use its own class instead.