### PR TITLE
Check if 'file' formdata is passed before using

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/dropwizard/endpoints/TabularUpload.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/dropwizard/endpoints/TabularUpload.java
@@ -72,6 +72,13 @@ public class TabularUpload {
     final Either<Response, Response> result = authCheck.getOrCreate(authHeader, ownerId, dataSetId, forceCreation)
       .flatMap(userAndDs -> authCheck.hasAdminAccess(userAndDs.getLeft(), userAndDs.getRight()))
       .map(userAndDs -> {
+        if (rdfInputStream == null || body == null || fileInfo == null) {
+          return errorResponseHelper.error(
+            400,
+            "Missing form parameter 'file'. In curl you'd use `-F \"file=@<filename>;type=<mediatype>\"`."
+          );
+        }
+
         final MediaType mediaType = mimeTypeOverride == null ? body.getMediaType() : mimeTypeOverride;
 
         Optional<Loader> loader = LoaderFactory.createFor(mediaType.toString(), formData.getFields().entrySet().stream()


### PR DESCRIPTION
The @FormDataParam 'file' is used via three separate parameters:
'rdfInputStream', 'body' and 'fileInfo'

These were not yet checked for non-nullness, which they are when
a user fails to pass '-F "file=@some_file;type=some_type"'.

This commit checks these parameters before their first use and
returns a 400 accompanied by an informative error message along
the lines of the message already present further down the method.