### PR TITLE
Update Jackson to v2.9.6

### DIFF
--- a/ContractDiff/pom.xml
+++ b/ContractDiff/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.3</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.3</version>
+      <version>2.9.6</version>
     </dependency>
 
     <dependency>

--- a/timbuctoo-instancev4/pom.xml
+++ b/timbuctoo-instancev4/pom.xml
@@ -123,7 +123,7 @@
     <!-- code dependencies -->
     <activemq.version>5.13.0</activemq.version>
     <concoridion.version>1.5.1</concoridion.version>
-    <dropwizard.version>1.2.1</dropwizard.version>
+    <dropwizard.version>1.2.9</dropwizard.version>
     <dropwizard-activemq.version>0.3.13</dropwizard-activemq.version>
     <jsonassert.version>1.2.3</jsonassert.version>
     <tinkerpop3.version>3.1.0-incubating</tinkerpop3.version>
@@ -426,17 +426,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.9.1</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.9.1</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>2.9.1</version>
+      <version>2.9.6</version>
     </dependency>
     <!-- ### Std lib additions ## -->
 


### PR DESCRIPTION
Includes a patch update of dropwizard to 1.2.9 to make sure all jackson dependencies are set to v2.9.6.