### PR TITLE
Make DatabaseGetter handle database errors

### DIFF
--- a/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/berkeleydb/DatabaseGetter.java
+++ b/timbuctoo-instancev4/src/main/java/nl/knaw/huygens/timbuctoo/v5/berkeleydb/DatabaseGetter.java
@@ -453,7 +453,7 @@ public class DatabaseGetter<KeyT, ValueT> {
           } else {
             status = iteration.apply(cursor);
           }
-        } catch (DatabaseException e) {
+        } catch (DatabaseException | IllegalStateException e) {
           LOG.error("Database exception!", e);
           status = OperationStatus.NOTFOUND;
         }


### PR DESCRIPTION
The IllegalArgumentException is thrown when the database is closed or when a transaction is aborted.